### PR TITLE
Ignore stackframes from this package in assertions

### DIFF
--- a/array.go
+++ b/array.go
@@ -7,6 +7,9 @@ import (
 )
 
 func (a *Asserter) checkArray(path string, act, exp []interface{}) {
+	if t, ok := a.Printer.(tt); ok {
+		t.Helper()
+	}
 	if len(act) != len(exp) {
 		a.Printer.Errorf("length of arrays at '%s' were different. Expected array to be of length %d, but contained %d element(s)", path, len(exp), len(act))
 		serializedAct, serializedExp := serialize(act), serialize(exp)

--- a/boolean.go
+++ b/boolean.go
@@ -13,6 +13,9 @@ func extractBoolean(b string) (bool, error) {
 }
 
 func (a *Asserter) checkBoolean(path string, act, exp bool) {
+	if t, ok := a.Printer.(tt); ok {
+		t.Helper()
+	}
 	if act != exp {
 		a.Printer.Errorf("expected boolean at '%s' to be %v but was %v", path, exp, act)
 	}

--- a/core.go
+++ b/core.go
@@ -8,6 +8,9 @@ import (
 )
 
 func (a *Asserter) pathassertf(path, act, exp string) {
+	if t, ok := a.Printer.(tt); ok {
+		t.Helper()
+	}
 	if act == exp {
 		return
 	}
@@ -101,4 +104,13 @@ func findType(j string) (jsonType, error) {
 		return jsonArray, nil
 	}
 	return jsonTypeUnknown, fmt.Errorf(`unable to identify JSON type of "%s"`, j)
+}
+
+// *testing.T has a Helper() func that allow testing tools like this package to
+// ignore their own frames when calling Errorf on *testing.T instances.
+// This interface is here to avoid breaking backwards compatibility in terms of
+// the interface we expect in New.
+type tt interface {
+	Printer
+	Helper()
 }

--- a/exports.go
+++ b/exports.go
@@ -54,5 +54,8 @@ func New(p Printer) *Asserter {
 // You may use "<<PRESENCE>>" against any type of value. The only exception is null, which
 // will result in an assertion failure.
 func (a *Asserter) Assertf(actualJSON, expectedJSON string, fmtArgs ...interface{}) {
+	if t, ok := a.Printer.(tt); ok {
+		t.Helper()
+	}
 	a.pathassertf("$", actualJSON, fmt.Sprintf(expectedJSON, fmtArgs...))
 }

--- a/number.go
+++ b/number.go
@@ -9,6 +9,9 @@ import (
 const minDiff = 0.000001
 
 func (a *Asserter) checkNumber(path string, act, exp float64) {
+	if t, ok := a.Printer.(tt); ok {
+		t.Helper()
+	}
 	diff := math.Abs(act - exp)
 	if diff > minDiff {
 		a.Printer.Errorf("expected number at '%s' to be '%.7f' but was '%.7f'", path, exp, act)

--- a/object.go
+++ b/object.go
@@ -7,6 +7,9 @@ import (
 )
 
 func (a *Asserter) checkObject(path string, act, exp map[string]interface{}) {
+	if t, ok := a.Printer.(tt); ok {
+		t.Helper()
+	}
 	if len(act) != len(exp) {
 		a.Printer.Errorf("expected %d keys at '%s' but got %d keys", len(exp), path, len(act))
 	}

--- a/string.go
+++ b/string.go
@@ -7,6 +7,9 @@ import (
 )
 
 func (a *Asserter) checkString(path, act, exp string) {
+	if t, ok := a.Printer.(tt); ok {
+		t.Helper()
+	}
 	if act != exp {
 		if len(exp+act) < 50 {
 			a.Printer.Errorf("expected string at '%s' to be '%s' but was '%s'", path, exp, act)


### PR DESCRIPTION
This means that the line number at which a test assertion appeared will
show up at the right line of code relative to what the user wrote, as
opposed to where in this package it appeared.

CC: @CodeHex - beat you to it