### PR TITLE
More gracefully make calls to Helper()

### DIFF
--- a/array.go
+++ b/array.go
@@ -7,16 +7,14 @@ import (
 )
 
 func (a *Asserter) checkArray(path string, act, exp []interface{}) {
-	if t, ok := a.Printer.(tt); ok {
-		t.Helper()
-	}
+	a.tt.Helper()
 	if len(act) != len(exp) {
-		a.Printer.Errorf("length of arrays at '%s' were different. Expected array to be of length %d, but contained %d element(s)", path, len(exp), len(act))
+		a.tt.Errorf("length of arrays at '%s' were different. Expected array to be of length %d, but contained %d element(s)", path, len(exp), len(act))
 		serializedAct, serializedExp := serialize(act), serialize(exp)
 		if len(serializedAct+serializedExp) < 50 {
-			a.Printer.Errorf("actual JSON at '%s' was: %+v, but expected JSON was: %+v", path, serializedAct, serializedExp)
+			a.tt.Errorf("actual JSON at '%s' was: %+v, but expected JSON was: %+v", path, serializedAct, serializedExp)
 		} else {
-			a.Printer.Errorf("actual JSON at '%s' was:\n%+v\nbut expected JSON was:\n%+v", path, serializedAct, serializedExp)
+			a.tt.Errorf("actual JSON at '%s' was:\n%+v\nbut expected JSON was:\n%+v", path, serializedAct, serializedExp)
 		}
 		return
 	}

--- a/boolean.go
+++ b/boolean.go
@@ -13,10 +13,8 @@ func extractBoolean(b string) (bool, error) {
 }
 
 func (a *Asserter) checkBoolean(path string, act, exp bool) {
-	if t, ok := a.Printer.(tt); ok {
-		t.Helper()
-	}
+	a.tt.Helper()
 	if act != exp {
-		a.Printer.Errorf("expected boolean at '%s' to be %v but was %v", path, exp, act)
+		a.tt.Errorf("expected boolean at '%s' to be %v but was %v", path, exp, act)
 	}
 }

--- a/core.go
+++ b/core.go
@@ -8,33 +8,31 @@ import (
 )
 
 func (a *Asserter) pathassertf(path, act, exp string) {
-	if t, ok := a.Printer.(tt); ok {
-		t.Helper()
-	}
+	a.tt.Helper()
 	if act == exp {
 		return
 	}
 	actType, err := findType(act)
 	if err != nil {
-		a.Printer.Errorf("'actual' JSON is not valid JSON: " + err.Error())
+		a.tt.Errorf("'actual' JSON is not valid JSON: " + err.Error())
 		return
 	}
 	expType, err := findType(exp)
 	if err != nil {
-		a.Printer.Errorf("'expected' JSON is not valid JSON: " + err.Error())
+		a.tt.Errorf("'expected' JSON is not valid JSON: " + err.Error())
 		return
 	}
 
 	// If we're only caring about the presence of the key, then don't bother checking any further
 	if expPresence, _ := extractString(exp); expPresence == "<<PRESENCE>>" {
 		if actType == jsonNull {
-			a.Printer.Errorf(`expected the presence of any value at '%s', but was absent`, path)
+			a.tt.Errorf(`expected the presence of any value at '%s', but was absent`, path)
 		}
 		return
 	}
 
 	if actType != expType {
-		a.Printer.Errorf("actual JSON (%s) and expected JSON (%s) were of different types at '%s'", actType, expType, path)
+		a.tt.Errorf("actual JSON (%s) and expected JSON (%s) were of different types at '%s'", actType, expType, path)
 		return
 	}
 	switch actType {

--- a/helper.go
+++ b/helper.go
@@ -1,0 +1,14 @@
+package jsonassert
+
+// noopHelperTT is used to wrap the Printer in the case that users pass in an
+// Printer which does not implement a Helper() method. *testing.T does
+// implement this method so it is believed that this utility will be largely
+// unused.
+type noopHelperTT struct {
+	Printer
+}
+
+// Helper does nothing, intentionally. See New(Printer).
+func (*noopHelperTT) Helper() {
+	// Intentional NOOP
+}

--- a/integration_test.go
+++ b/integration_test.go
@@ -117,84 +117,6 @@ but expected JSON was:
 	}
 }
 
-type testTT struct {
-	testPrinter
-	invokedCount int
-}
-
-func (tt *testTT) Helper() {
-	tt.invokedCount++
-}
-
-func TestHelperGetsCalled(t *testing.T) {
-	testTable := []struct {
-		name     string
-		in       string
-		exp      string
-		expCount int
-	}{
-		{
-			name:     "1 at the top level, 1 for core",
-			in:       `null`,
-			exp:      `""`,
-			expCount: 2,
-		},
-		{
-			name:     "1 at the top level, 1 for core, 1 for boolean",
-			in:       `true`,
-			exp:      `false`,
-			expCount: 3,
-		},
-		{
-			name:     "1 at the top level, 1 for core, 1 for string",
-			in:       `"hello"`,
-			exp:      `"henlo"`,
-			expCount: 3,
-		},
-		{
-			name:     "1 at the top level, 1 for core, 1 for number",
-			in:       `1234`,
-			exp:      `4321`,
-			expCount: 3,
-		},
-		{
-			name:     "1 at the top level, 2 for core, 1 for object, 1 for string",
-			in:       `{"hello": "world"}`,
-			exp:      `{"hello": "世界"}`,
-			expCount: 5,
-		},
-		{
-			name:     "1 at the top level, 2 for core, 2 for object, 2 for string",
-			in:       `{"hello": {"name": "kinbiko"}}`,
-			exp:      `{"hello": {"name": "他の人"}}`,
-			expCount: 7,
-		},
-		{
-			name:     "1 at the top level, 2 for core, 1 for array, 2 for string",
-			in:       `["hello", "world"]`,
-			exp:      `["hello", "世界"]`,
-			expCount: 6,
-		},
-		{
-			name:     "1 at the top level, 4 for core, 3 for array, 4 for string",
-			in:       `[["hello", "world"], ["bye", "moon"]]`,
-			exp:      `[["hello", "世界"], ["bye", "月"]]`,
-			expCount: 13,
-		},
-	}
-
-	for _, tc := range testTable {
-		t.Run(tc.name, func(st *testing.T) {
-			tt := &testTT{}
-			ja := jsonassert.New(tt)
-			ja.Assertf(tc.in, tc.exp) // assertions should never fail
-			if got := tt.invokedCount; got != tc.expCount {
-				st.Errorf("expected %d calls to Helper but got %d", tc.expCount, got)
-			}
-		})
-	}
-}
-
 func setup() (*testPrinter, *jsonassert.Asserter) {
 	tp := &testPrinter{}
 	return tp, jsonassert.New(tp)
@@ -206,4 +128,8 @@ type testPrinter struct {
 
 func (tp *testPrinter) Errorf(msg string, args ...interface{}) {
 	tp.messages = append(tp.messages, fmt.Sprintf(msg, args...))
+}
+
+func (tp *testPrinter) Helper() {
+	// Do nothing in tests
 }

--- a/number.go
+++ b/number.go
@@ -9,12 +9,9 @@ import (
 const minDiff = 0.000001
 
 func (a *Asserter) checkNumber(path string, act, exp float64) {
-	if t, ok := a.Printer.(tt); ok {
-		t.Helper()
-	}
-	diff := math.Abs(act - exp)
-	if diff > minDiff {
-		a.Printer.Errorf("expected number at '%s' to be '%.7f' but was '%.7f'", path, exp, act)
+	a.tt.Helper()
+	if diff := math.Abs(act - exp); diff > minDiff {
+		a.tt.Errorf("expected number at '%s' to be '%.7f' but was '%.7f'", path, exp, act)
 	}
 }
 

--- a/object.go
+++ b/object.go
@@ -7,17 +7,15 @@ import (
 )
 
 func (a *Asserter) checkObject(path string, act, exp map[string]interface{}) {
-	if t, ok := a.Printer.(tt); ok {
-		t.Helper()
-	}
+	a.tt.Helper()
 	if len(act) != len(exp) {
-		a.Printer.Errorf("expected %d keys at '%s' but got %d keys", len(exp), path, len(act))
+		a.tt.Errorf("expected %d keys at '%s' but got %d keys", len(exp), path, len(act))
 	}
 	if unique := difference(act, exp); len(unique) != 0 {
-		a.Printer.Errorf("unexpected object key(s) %+v found at '%s'", serialize(unique), path)
+		a.tt.Errorf("unexpected object key(s) %+v found at '%s'", serialize(unique), path)
 	}
 	if unique := difference(exp, act); len(unique) != 0 {
-		a.Printer.Errorf("expected object key(s) %+v missing at '%s'", serialize(unique), path)
+		a.tt.Errorf("expected object key(s) %+v missing at '%s'", serialize(unique), path)
 	}
 	for key := range act {
 		if contains(exp, key) {

--- a/string.go
+++ b/string.go
@@ -7,14 +7,12 @@ import (
 )
 
 func (a *Asserter) checkString(path, act, exp string) {
-	if t, ok := a.Printer.(tt); ok {
-		t.Helper()
-	}
+	a.tt.Helper()
 	if act != exp {
 		if len(exp+act) < 50 {
-			a.Printer.Errorf("expected string at '%s' to be '%s' but was '%s'", path, exp, act)
+			a.tt.Errorf("expected string at '%s' to be '%s' but was '%s'", path, exp, act)
 		} else {
-			a.Printer.Errorf("expected string at '%s' to be\n'%s'\nbut was\n'%s'", path, exp, act)
+			a.tt.Errorf("expected string at '%s' to be\n'%s'\nbut was\n'%s'", path, exp, act)
 		}
 	}
 }


### PR DESCRIPTION
Instead of checking if the printer adheres to the testing.tt interface
throughout, wrap any non-matching types in a utility with a NOOP
Helper() implementation.

Removes the unnecessary exposure of the provided Printer in the
Asserter.
In the strictest sense, this change isn't backwards compatible, in that
Asserter no longer exposes a Printer field.
If for some obscure reason this affects you, you can replace all calls
to ja.Printer with the type that you passed in to New().