### PR TITLE
chore: Go version bump and other maintenance chores

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,31 +5,22 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.17
-        uses: actions/setup-go@v1
+      - name: Set up Go
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.17
+          go-version: 1.22
         id: go
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v1
-
-      - name: Get dependencies
-        run: go get -v -t -d ./...
-
-      - name: Build
-        run: go build -v .
+        uses: actions/checkout@v4
 
       - name: Test (race)
-        run: go test -race -v -coverprofile=profile.cov -covermode=atomic ./...
+        run: make coverage
 
       - name: Coverage
         uses: shogo82148/actions-goveralls@v1
         with:
           path-to-profile: profile.cov
 
-      - name: Install Linter
-        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.45.2
-
       - name: Lint
-        run: ./bin/golangci-lint run .
+        run: make lint

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@
 *.out
 
 tags
+
+bin/

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,7 +26,7 @@ linters-settings:
 
   govet:
     # report about shadowed variables
-    check-shadowing: true
+    shadow: true
 
     # enable or disable analyzers by name
     # enable:
@@ -151,12 +151,6 @@ linters:
 
     - depguard
 
-      # These are apparently deprecated but still yell at you if you don't disable them
-    - golint
-    - scopelint
-    - maligned
-    - interfacer
-
     - gci # This conflicts with goimports
     - varnamelen # This has too many false positives around indexes etc to be useful
   presets:
@@ -191,7 +185,7 @@ issues:
         - maintidx
     - path: \.go
       linters:
-        - goerr113
+        - err113
 
   # Independently from option `exclude` we use default exclude patterns,
   # it can be disabled by this option. To list all

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+LINTER_VERSION := v1.61.0
+
+.PHONY: check
+check: lint test
+
+.PHONY: get-deps
+get-deps:
+	go get -v -t -d ./...
+
+.PHONY: lint
+lint: ./bin/linter
+	./bin/linter run ./...
+
+.PHONY: test
+test:
+	go test -race -count=1 ./...
+
+.PHONY: coverage
+coverage:
+	go test -race -v -coverprofile=profile.cov -covermode=atomic ./...
+
+bin/linter: Makefile
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./bin $(LINTER_VERSION)
+	mv ./bin/golangci-lint ./bin/linter

--- a/exports.go
+++ b/exports.go
@@ -127,3 +127,10 @@ func (a *Asserter) Assertf(actualJSON, expectedJSON string, fmtArgs ...interface
 	a.tt.Helper()
 	a.pathassertf("$", actualJSON, fmt.Sprintf(expectedJSON, fmtArgs...))
 }
+
+// Assert works like Assertf, but does not accept fmt.Sprintf directives.
+// See Assert for details.
+func (a *Asserter) Assert(actualJSON, expectedJSON string) {
+	a.tt.Helper()
+	a.pathassertf("$", actualJSON, expectedJSON)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/kinbiko/jsonassert
 
-go 1.19
+go 1.22

--- a/integration_test.go
+++ b/integration_test.go
@@ -28,7 +28,6 @@ func TestAssertf(t *testing.T) {
 				"negative floats": {`-12.345`, `-12.345`, nil},
 				"strings":         {`"hello world"`, `"hello world"`, nil},
 			} {
-				tc := tc
 				t.Run(name, func(t *testing.T) { tc.check(t) })
 			}
 		})
@@ -44,7 +43,6 @@ func TestAssertf(t *testing.T) {
 				"strings":                  {`"hello"`, `"world"`, []string{`expected string at '$' to be 'world' but was 'hello'`}},
 				"empty v non-empty string": {`""`, `"world"`, []string{`expected string at '$' to be 'world' but was ''`}},
 			} {
-				tc := tc
 				t.Run(name, func(t *testing.T) { tc.check(t) })
 			}
 		})
@@ -82,7 +80,6 @@ func TestAssertf(t *testing.T) {
 					},
 				},
 			} {
-				tc := tc
 				t.Run(name, func(t *testing.T) { tc.check(t) })
 			}
 		})
@@ -112,7 +109,6 @@ func TestAssertf(t *testing.T) {
 					},
 				},
 			} {
-				tc := tc
 				t.Run(name, func(t *testing.T) { tc.check(t) })
 			}
 		})
@@ -151,7 +147,6 @@ func TestAssertf(t *testing.T) {
 					nil,
 				},
 			} {
-				tc := tc
 				t.Run(name, func(t *testing.T) { tc.check(t) })
 			}
 		})
@@ -205,7 +200,6 @@ but expected JSON was:
 					},
 				},
 			} {
-				tc := tc
 				t.Run(name, func(t *testing.T) { tc.check(t) })
 			}
 		})
@@ -247,7 +241,6 @@ but expected JSON was:
 					},
 				},
 			} {
-				tc := tc
 				t.Run(name, func(t *testing.T) { tc.check(t) })
 			}
 		})
@@ -313,7 +306,6 @@ but expected JSON was:
 					nil,
 				},
 			} {
-				tc := tc
 				t.Run(name, func(t *testing.T) { tc.check(t) })
 			}
 		})
@@ -345,7 +337,6 @@ potentially in a different order`,
 				},
 			},
 		} {
-			tc := tc
 			t.Run(name, func(t *testing.T) { tc.check(t) })
 		}
 	})
@@ -461,7 +452,7 @@ type testCase struct {
 func (tc *testCase) check(t *testing.T) {
 	t.Helper()
 	tp := &testPrinter{messages: nil}
-	jsonassert.New(tp).Assertf(tc.act, tc.exp)
+	jsonassert.New(tp).Assert(tc.act, tc.exp)
 
 	if got := len(tp.messages); got != len(tc.msgs) {
 		t.Errorf("expected %d assertion message(s) but got %d", len(tc.msgs), got)


### PR DESCRIPTION
- Introduce a Makefile for easier consistent usage of tools (mainly the
  linter) locally and in CI
- Add an `Assert` (no `f` suffix), since `go vet` has started
  complaining about that.
- Bump project Go version
- Bump GitHub actions versions
- Address new lint violations

Closes #45

## Checklist

- [x] I have done a self-review of the PR.
